### PR TITLE
Migrate to poetry

### DIFF
--- a/build.py
+++ b/build.py
@@ -1,0 +1,76 @@
+import os
+import sys
+import numpy
+from distutils.core import Extension
+
+try:
+    from Cython.Build import cythonize
+except ImportError:
+    USE_CYTHON = False
+else:
+    USE_CYTHON = True
+
+ext = ".pyx" if USE_CYTHON else ".c"
+extension_args = {
+    "language": "c",
+    "extra_compile_args": ["-fopenmp", "-std=c99"],
+    "extra_link_args": ["-lgomp", "-Wl,-rpath,/usr/local/lib"],
+    "libraries": ["gsl", "gslcblas", "fftw3", "fftw3f", "fftw3_omp", "fftw3f_omp"],
+    "library_dirs": ["/usr/local/lib", os.path.join(sys.prefix, "lib")],
+    "include_dirs": [
+        numpy.get_include(),
+        os.path.join(sys.prefix, "include"),
+        os.path.join(os.path.dirname(__file__), "pyrost/include"),
+        os.path.join(os.path.dirname(__file__), "pyrost/bin"),
+    ],
+}
+
+src_files = [
+    "pyrost/include/pocket_fft.c",
+    "pyrost/include/fft_functions.c",
+    "pyrost/include/array.c",
+    "pyrost/include/routines.c",
+    "pyrost/include/median.c",
+]
+extensions = [
+    Extension(
+        name="pyrost.bin.simulation",
+        sources=[
+            "pyrost/bin/simulation" + ext,
+        ]
+        + src_files,
+        **extension_args
+    ),
+    Extension(
+        name="pyrost.bin.pyfftw",
+        sources=[
+            "pyrost/bin/pyfftw" + ext,
+        ],
+        **extension_args
+    ),
+    Extension(
+        name="pyrost.bin.pyrost",
+        sources=[
+            "pyrost/bin/pyrost" + ext,
+        ],
+        **extension_args
+    ),
+]
+
+if USE_CYTHON:
+    extensions = cythonize(
+        extensions,
+        annotate=True,
+        language_level="3",
+        compiler_directives={
+            "cdivision": True,
+            "boundscheck": False,
+            "wraparound": False,
+            "binding": True,
+            "embedsignature": False,
+        },
+    )
+
+
+def build(setup_kwargs):
+    setup_kwargs.update({"ext_modules": extensions})

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,20 @@
+[tool.poetry]
+name = "pyrost"
+version = "0.7.6"
+description = "Python Robust Speckle Tracking (pyrost) is a library for wavefront metrology and sample imaging based on ptychographic speckle tracking algorithm."
+authors = ["Nikolay Ivanov <nikolay.ivanov@desy.de>"]
+license = "GPL-3.0-or-later"
+readme = "README.md"
+build = 'build.py'
+
+[tool.poetry.dependencies]
+python = ">=3.6"
+h5py = ">=2.10.0"
+numpy = ">=1.19.0"
+scipy = ">=1.5.2"
+tqdm = ">=4.56.0"
+
+
+[build-system]
+requires = ["poetry-core", "setuptools", "numpy", "cython"]
+build-backend = "poetry.core.masonry.api"

--- a/setup.py
+++ b/setup.py
@@ -1,63 +1,34 @@
-import os
-import sys
-from setuptools import setup, find_namespace_packages
-from distutils.core import Extension
-import numpy
+# -*- coding: utf-8 -*-
+from setuptools import setup
 
-try:
-    from Cython.Build import cythonize
-except ImportError:
-    USE_CYTHON = False
-else:
-    USE_CYTHON = True
+packages = \
+['pyrost', 'pyrost.bin', 'pyrost.multislice', 'pyrost.simulation']
 
-ext = '.pyx' if USE_CYTHON else '.c'
-extension_args = {'language': 'c',
-                  'extra_compile_args': ['-fopenmp', '-std=c99'],
-                  'extra_link_args': ['-lgomp', '-Wl,-rpath,/usr/local/lib'],
-                  'libraries': ['gsl', 'gslcblas', 'fftw3', 'fftw3f', 'fftw3_omp', 'fftw3f_omp'],
-                  'library_dirs': ['/usr/local/lib',
-                                   os.path.join(sys.prefix, 'lib')],
-                  'include_dirs': [numpy.get_include(),
-                                   os.path.join(sys.prefix, 'include'),
-                                   os.path.join(os.path.dirname(__file__), 'pyrost/include'),
-                                   os.path.join(os.path.dirname(__file__), 'pyrost/bin')]}
+package_data = \
+{'': ['*'], 'pyrost': ['config/*', 'data/*', 'include/*']}
 
-src_files = ["pyrost/include/pocket_fft.c", "pyrost/include/fft_functions.c",
-             "pyrost/include/array.c", "pyrost/include/routines.c", "pyrost/include/median.c"]
-extensions = [Extension(name='pyrost.bin.simulation',
-                        sources=['pyrost/bin/simulation' + ext,] + src_files, **extension_args),
-              Extension(name='pyrost.bin.pyfftw',
-                        sources=['pyrost/bin/pyfftw' + ext,], **extension_args),
-              Extension(name='pyrost.bin.pyrost',
-                        sources=['pyrost/bin/pyrost' + ext,], **extension_args),]
+install_requires = \
+['h5py>=2.10.0,<3.0.0',
+ 'numpy>=1.19.0,<2.0.0',
+ 'scipy>=1.5.2,<2.0.0',
+ 'tqdm>=4.56.0,<5.0.0']
 
-if USE_CYTHON:
-    extensions = cythonize(extensions, annotate=True, language_level="3",
-                           compiler_directives={'cdivision': True,
-                                                'boundscheck': False,
-                                                'wraparound': False,
-                                                'binding': True,
-                                                'embedsignature': False})
+setup_kwargs = {
+    'name': 'pyrost',
+    'version': '0.7.6',
+    'description': 'Python Robust Speckle Tracking (pyrost) is a library for wavefront metrology and sample imaging based on ptychographic speckle tracking algorithm.',
+    'long_description': "## Current build status\n[![PyPI](https://img.shields.io/pypi/v/pyrost?color=brightgreen)](https://pypi.org/project/pyrost/)\n[![Documentation Status](https://readthedocs.org/projects/robust-speckle-tracking/badge/?version=latest)](https://robust-speckle-tracking.readthedocs.io/en/latest/?badge=latest)\n[![conda-forge](https://img.shields.io/conda/vn/conda-forge/pyrost?color=brightgreen)](https://anaconda.org/conda-forge/pyrost)\n[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.6574364.svg)](https://doi.org/10.5281/zenodo.6574364)\n\n# pyrost\nPython Robust Speckle Tracking (**pyrost**) is a library for wavefront metrology\nand sample imaging based on ptychographic speckle tracking algorithm. This\nproject takes over Andrew Morgan's [speckle_tracking](https://github.com/andyofmelbourne/speckle-tracking)\nproject as an improved version aiming to add robustness to the optimisation\nalgorithm in the case of the high noise present in the measured data.\n\nThe documentation can be found on [Read the Docs](https://robust-speckle-tracking.readthedocs.io/en/latest/).\n\nRead the open access scientific article about the technical details of the developed technique published in [Optica Express](https://opg.optica.org/oe/abstract.cfm?URI=oe-30-14-25450).\n\n## Dependencies\n\n- [Python](https://www.python.org/) 3.6 or later (Python 2.x is **not** supported).\n- [GNU Scientific Library](https://www.gnu.org/software/gsl/) 2.4 or later.\n- [LLVM's OpenMP library](http://openmp.llvm.org) 10.0.0 or later.\n- [FFTW](http://www.fftw.org) 3.3.8 or later.\n- [h5py](https://www.h5py.org) 2.10.0 or later.\n- [NumPy](https://numpy.org) 1.19.0 or later.\n- [SciPy](https://scipy.org) 1.5.2 or later.\n- [tqdm](https://github.com/tqdm/tqdm) 4.56.0 or later.\n\n## Installation\nWe recommend **not** building from source, but install the release via the\n[conda](https://anaconda.org/conda-forge/pyrost) manager:\n\n    conda install -c conda-forge pyrost\n\nThe package is available in [conda-forge](https://anaconda.org/conda-forge/pyrost) on OS X and Linux.\n\nAlso you can install the release from [pypi](https://pypi.org/project/pyrost/)\nwith the pip package installer:\n\n    pip install pyrost\n\nThe source distribution is available in [pypi](https://pypi.org/project/pyrost/) as for now.\n\n## Installation from source\nIn order to build the package from source simply execute the following command:\n\n    python setup.py install\n\nor:\n\n    pip install -r requirements.txt -e . -v\n\nThat cythonizes the Cython extensions and builds them into ``/pyrost/bin``.",
+    'author': 'Nikolay Ivanov',
+    'author_email': 'nikolay.ivanov@desy.de',
+    'maintainer': 'None',
+    'maintainer_email': 'None',
+    'url': 'None',
+    'packages': packages,
+    'package_data': package_data,
+    'install_requires': install_requires,
+    'python_requires': '>=3.6,<4.0',
+}
+from build import *
+build(setup_kwargs)
 
-with open('README.md', 'r') as readme:
-    long_description = readme.read()
-
-setup(name='pyrost',
-      version='0.7.6',
-      author='Nikolay Ivanov',
-      author_email="nikolay.ivanov@desy.de",
-      long_description=long_description,
-      long_description_content_type='text/markdown',
-      url="https://github.com/simply-nicky/pyrost",
-      packages=find_namespace_packages(),
-      include_package_data=True,
-      install_requires=['h5py', 'numpy', 'scipy'],
-      extras_require={'interactive': ['matplotlib', 'jupyter', 'pyximport', 'ipykernel', 'ipywidgets']},
-      ext_modules=extensions,
-      classifiers=[
-          "Programming Language :: Python",
-          "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
-          "Operating System :: OS Independent"
-      ],
-      python_requires='>=3.6')
+setup(**setup_kwargs)


### PR DESCRIPTION
Ivan and I were trying to install pyrost via pip in a virtual environment today. This failed, because `setup.py` has a dependency on `numpy`. However, if you're trying to install dependencies and this, in turn, needs dependencies, `pip` is completely out of its depth and fails because "numpy wasn't found".

The standard solution to this is `pip install numpy; pip install pyrost` inside your project. But that seems like an extra step, really. `pip install pyrost` should just work.

I solved this in a rather brutal fashion by foregoing `setuptools` an replacing it with [poetry](https://python-poetry.org), which does have the notion of these "build-time dependencies".

To make it work, you have to write a `pyproject.toml` file and add your dependencies (note the `requires` in `build-system` for the build-time dependencies). When you do `poetry build`, it generates a `setup.py` and executes the build process.

This works, and even allows `pip install` again:
```
pip install git+https://github.com/pmiddend/pyrost@migrate-to-poetry
```

Maybe, for you, it might be enough to just commit the modified `setup.py`. Not sure. poetry is definitely a nice piece of software.